### PR TITLE
Expose didPopListeners so that we could execute them when we want to …

### DIFF
--- a/Source/JavaScriptCore/runtime/VMEntryScope.h
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.h
@@ -43,6 +43,9 @@ public:
 
     JSGlobalObject* globalObject() const { return m_globalObject; }
 
+    Vector<std::function<void()>>& didPopListeners() {
+      return this->m_didPopListeners;
+    }
     void addDidPopListener(std::function<void ()>);
 
 private:


### PR DESCRIPTION
…attach a debugger to a running application

Related to: https://github.com/NativeScript/ios-runtime/pull/561
