### PR TITLE
LiveEdit changes

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -468,6 +468,11 @@ void InspectorDebuggerAgent::getScriptSource(ErrorString& error, const String& s
     else
         error = ASCIILiteral("No script for id: ") + scriptIDStr;
 }
+    
+void InspectorDebuggerAgent::setScriptSource(ErrorString& error, const String& scriptID, const String& scriptSource)
+{
+    
+}
 
 void InspectorDebuggerAgent::getFunctionDetails(ErrorString& errorString, const String& functionId, RefPtr<Inspector::Protocol::Debugger::FunctionDetails>& details)
 {

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -73,6 +73,7 @@ public:
     virtual void continueToLocation(ErrorString&, const InspectorObject& location) override;
     virtual void searchInContent(ErrorString&, const String& scriptID, const String& query, const bool* optionalCaseSensitive, const bool* optionalIsRegex, RefPtr<Inspector::Protocol::Array<Inspector::Protocol::GenericTypes::SearchMatch>>&) override;
     virtual void getScriptSource(ErrorString&, const String& scriptID, String* scriptSource) override;
+    virtual void setScriptSource(ErrorString&, const String& scriptID, const String& scriptSource) override;
     virtual void getFunctionDetails(ErrorString&, const String& functionId, RefPtr<Inspector::Protocol::Debugger::FunctionDetails>&) override;
     virtual void pause(ErrorString&) override;
     virtual void resume(ErrorString&) override;

--- a/Source/JavaScriptCore/inspector/protocol/Debugger.json
+++ b/Source/JavaScriptCore/inspector/protocol/Debugger.json
@@ -224,6 +224,14 @@
             "description": "Returns source for the script with given id."
         },
         {
+            "name": "setScriptSource",
+             "parameters": [
+                { "name": "scriptUrl", "type": "string", "description": "Absolute location of the script to set source for." },
+                { "name": "scriptSource", "type": "string", "description": "Script source." }
+             ],
+            "description": "Set source for the script with given id."
+        },
+        {
             "name": "getFunctionDetails",
             "parameters": [
                 { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }

--- a/Source/JavaScriptCore/parser/SourceCode.h
+++ b/Source/JavaScriptCore/parser/SourceCode.h
@@ -98,9 +98,17 @@ namespace JSC {
         bool isNull() const { return !m_provider; }
         SourceProvider* provider() const { return m_provider.get(); }
         int firstLine() const { return m_firstLine; }
+        void setFirstLine(int firstLine) { m_firstLine = firstLine; }
+
         int startColumn() const { return m_startColumn; }
+        void startColumn(int startColumn) { m_startColumn = startColumn; }
+
         int startOffset() const { return m_startChar; }
+        void setStartOffset(int startChar) { m_startChar = startChar; }
+
         int endOffset() const { return m_endChar; }
+        void setEndOffset(int endChar) { m_endChar = endChar; }
+
         int length() const { return m_endChar - m_startChar; }
         
         SourceCode subExpression(unsigned openBrace, unsigned closeBrace, int firstLine, int startColumn);

--- a/Source/JavaScriptCore/runtime/Executable.h
+++ b/Source/JavaScriptCore/runtime/Executable.h
@@ -213,6 +213,10 @@ public:
         return OBJECT_OFFSETOF(ExecutableBase, m_numParametersForConstruct);
     }
 
+    void clearNumParametersForCall() {
+        m_numParametersForCall = -1;
+    }
+    
     bool hasJITCodeForCall() const
     {
         return m_numParametersForCall >= 0;


### PR DESCRIPTION
Add setScriptSource method in the Debug.json protocol Expose methods that would let us modify the offsets of the source code

Expose clearNumParametersForCall that sets the m_numParametersForCall to the default value. m_numParametersForCall is used to determine whether the function should regenerate its code block through  hasJITCodeFor (called from prepareForExecution)
