### PR TITLE
Expose dispatchers

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
@@ -101,6 +101,7 @@ public:
     RefPtr<InspectorObject> getObject(InspectorObject*, const String& name, bool* valueFound);
     RefPtr<InspectorArray> getArray(InspectorObject*, const String& name, bool* valueFound);
 
+    const HashMap<String, SupplementalBackendDispatcher*>& dispatchers() { return m_dispatchers; }
 private:
     BackendDispatcher(Ref<FrontendRouter>&&);
 


### PR DESCRIPTION
We want to be able to provide custom implementation for an already existing dispatcher, so expose the dispatcher and start acting like a proxy - if we have custom implementation call it, otherwise go through the official dispatcher