### PR TITLE
Allow inspection of the global scope in Chrome DevTools

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -583,6 +583,17 @@ InjectedScript.prototype = {
         return descriptors;
     },
 
+    _objectPrototype: function(object)
+    {
+        if (InjectedScriptHost.subtype(object) === "proxy")
+            return null;
+        try {
+            return Object.getPrototypeOf(object);
+        } catch (e) {
+            return null;
+        }
+    },
+
     _propertyDescriptors: function(object, collectionMode, nativeGettersAsValues)
     {
         if (InjectedScriptHost.subtype(object) === "proxy")
@@ -692,7 +703,7 @@ InjectedScript.prototype = {
             isArrayLike = injectedScript._subtype(object) === "array" && isFinite(object.length) && object.length > 0;
         } catch(e) {}
 
-        for (var o = object; this._isDefined(o); o = o.__proto__) {
+        for (var o = object; this._isDefined(o); o = this._objectPrototype(o)) {
             var isOwnProperty = o === object;
 
             if (isArrayLike && isOwnProperty)


### PR DESCRIPTION
Accessing `__proto__` does a `ToThis(...)` conversion on the receiver. In the case of GlobalObjects this would return undefined and throw an exception. Copied from: https://github.com/v8/v8/blob/d5a0860e87b5f8d88432cf628f4bbc0cc922317f/src/inspector/injected-script-source.js#L365-L374