### PR TITLE
Change executionContextId assert to know of Chrome DevTools

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
@@ -48,7 +48,7 @@ void JSGlobalObjectRuntimeAgent::didCreateFrontendAndBackend(FrontendRouter*, Ba
 
 InjectedScript JSGlobalObjectRuntimeAgent::injectedScriptForEval(ErrorString& errorString, const int* executionContextId)
 {
-    ASSERT_UNUSED(executionContextId, !executionContextId);
+    ASSERT_UNUSED(executionContextId, (!executionContextId || *executionContextId == 1));
 
     JSC::ExecState* scriptState = m_globalObject.globalExec();
     InjectedScript injectedScript = injectedScriptManager().injectedScriptFor(scriptState);


### PR DESCRIPTION
Assert that `executionContextId` is unused when debugging with Web Inspector and is equal to 1 when debugging with Chrome DevTools.

https://github.com/NativeScript/NativeScript/blob/0bb51e60653a865921f12a70c60c6671582a99a5/tns-core-modules/debugger/webinspector.ios.ts#L255