### PR TITLE
fix missing stack trace info in recreated Exception instances

### DIFF
--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -28,16 +28,25 @@
 
 #include "Interpreter.h"
 #include "JSCInlines.h"
+#include "stdio.h"
 
 namespace JSC {
 
 const ClassInfo Exception::s_info = { "Exception", &Base::s_info, 0, CREATE_METHOD_TABLE(Exception) };
-
+// static
+const char* Exception::NS_EXCEPTION_IDENTIFIER_STRING = "__nsException";
+    
 Exception* Exception::create(VM& vm, JSValue thrownValue, StackCaptureAction action)
 {
     Exception* result = new (NotNull, allocateCell<Exception>(vm.heap)) Exception(vm);
     result->finishCreation(vm, thrownValue, action);
+
     return result;
+}
+    
+JSValue Exception::defaultValue(const JSObject*, ExecState*, PreferredPrimitiveType)
+{
+    return jsUndefined();
 }
 
 void Exception::destroy(JSCell* cell)
@@ -72,7 +81,10 @@ Exception::~Exception()
 void Exception::finishCreation(VM& vm, JSValue thrownValue, StackCaptureAction action)
 {
     Base::finishCreation(vm);
-
+    JSObject* asObject = thrownValue.getObject();
+    if (asObject != nullptr) {
+        asObject->putDirect(vm, Identifier::fromString(&vm, NS_EXCEPTION_IDENTIFIER_STRING), this, DontEnum | ReadOnly | DontDelete);
+    }
     m_value.set(vm, this, thrownValue);
 
     Vector<StackFrame> stackTrace;

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -34,6 +34,7 @@ namespace JSC {
 class Exception : public JSNonFinalObject {
 public:
     typedef JSNonFinalObject Base;
+    static const char* NS_EXCEPTION_IDENTIFIER_STRING;
     static const unsigned StructureFlags = StructureIsImmortal | Base::StructureFlags;
 
     enum StackCaptureAction {
@@ -46,6 +47,7 @@ public:
     static void destroy(JSCell*);
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
+    static JSValue defaultValue(const JSObject*, ExecState*, PreferredPrimitiveType);
 
     static void visitChildren(JSCell*, SlotVisitor&);
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -602,8 +602,22 @@ void VM::throwException(ExecState* exec, Exception* exception)
 JSValue VM::throwException(ExecState* exec, JSValue thrownValue)
 {
     Exception* exception = jsDynamicCast<Exception*>(thrownValue);
-    if (!exception)
-        exception = Exception::create(*this, thrownValue);
+    if (!exception) {
+        // protect against throw null; in JavaScript
+        if (thrownValue.getObject() != nullptr) {
+            // Exception::create stores the Exception instance in the passed thrownValue. If we have an Exception instance here we reuse it instead of
+            // recreating it. In this way we keep the stack trace at the point where the original exception occured.
+            JSValue nsException = thrownValue.getObject()->getDirect(*this, Identifier::fromString(this, Exception::NS_EXCEPTION_IDENTIFIER_STRING));
+        
+            if (!nsException.isUndefinedOrNull() && nsException.isCell() && nsException.asCell() != nullptr ) {
+                exception = jsDynamicCast<Exception*>(nsException);
+            }
+        }
+        
+        if (!exception) {
+            exception = Exception::create(*this, thrownValue);
+        }
+    }
 
     throwException(exec, exception);
     return JSValue(exception);


### PR DESCRIPTION
We want to extend the Exception and VM.cpp logic to reuse Exception instances by storing them in a dedicated system property on the JavaScript thrown object. The change includes:
- write the original Exception instance on the JSValue passed to `Exception::create`
- refactor the `throwException` logic to try to reuse this instance if present

Let's discuss the feasibility of this approach.