### PR TITLE
Fix API incompatibiliy.

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::startTiming(const String&
     return nullptr;
 }
 
-std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::stopTiming(const String& title, PassRefPtr<ScriptCallStack> callStack)
+std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::stopTiming(const String& title, Ref<ScriptCallStack>&& callStack)
 
 {
     ASSERT(!title.isNull());
@@ -171,9 +171,9 @@ std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::stopTiming(const String& 
 
     double elapsed = monotonicallyIncreasingTime() - startTime;
     String message = title + String::format(": %.3fms", elapsed * 1000);
-    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack);
+    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(callStack));
     addMessageToConsole(WTFMove(consoleMessage));
-    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack);
+    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(callStack));
 }
 
 void InspectorConsoleAgent::takeHeapSnapshot(const String& title)

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -171,9 +171,9 @@ std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::stopTiming(const String& 
 
     double elapsed = monotonicallyIncreasingTime() - startTime;
     String message = title + String::format(": %.3fms", elapsed * 1000);
-    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(callStack));
+    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack.copyRef());
     addMessageToConsole(WTFMove(consoleMessage));
-    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(callStack));
+    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack.copyRef());
 }
 
 void InspectorConsoleAgent::takeHeapSnapshot(const String& title)

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -70,7 +70,7 @@ public:
     void addMessageToConsole(std::unique_ptr<ConsoleMessage>);
 
     std::unique_ptr<ConsoleMessage> startTiming(const String& title);
-    std::unique_ptr<ConsoleMessage> stopTiming(const String& title, PassRefPtr<ScriptCallStack>);
+    std::unique_ptr<ConsoleMessage> stopTiming(const String& title, Ref<ScriptCallStack>&&);
     
     void takeHeapSnapshot(const String& title);
     void count(JSC::ExecState*, Ref<ScriptArguments>&&);


### PR DESCRIPTION
Since the Console.time() fix was targeted against the ios branch of our Webkit fork and there are API changes in the ios-11 branch we need to refactor it a bit to be compatible.