### PR TITLE
Reapply dataLocation addres fix over iOS 11.2.5.

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
@@ -328,7 +328,7 @@ public:
     {
         m_value.assertIsPoisoned();
         ASSERT_VALID_CODE_POINTER(m_value);
-        return bitwise_cast<T>(m_value ? m_value.unpoisoned<char*>() - 1 : nullptr);
+        return bitwise_cast<T>(m_value ? m_value.unpoisoned<char*>() - 1 - 1 : nullptr);
     }
 #else
     template<typename T = void*>


### PR DESCRIPTION
Reapplying https://github.com/NativeScript/webkit/commit/0e63c2871e81ef9d9101f5f3b2aaf6db0cf8e5f2 which was overwritten after merging 11.2.5 changes.