### PR TITLE
Wrap private api calls in preprocessor checks

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocatorFixedVMPool.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocatorFixedVMPool.cpp
@@ -161,9 +161,10 @@ protected:
     }
 
 private:
-#if OS(DARWIN) && HAVE(REMAP_JIT)
+#if OS(DARWIN) && HAVE(REMAP_JIT) && USE(APPLE_INTERNAL_SDK)
     void initializeSeparatedWXHeaps(void* stubBase, size_t stubSize, void* jitBase, size_t jitSize)
     {
+        
         mach_vm_address_t writableAddr = 0;
 
         // Create a second mapping of the JIT region at a random address.

--- a/Source/WebCore/crypto/mac/CryptoKeyMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyMac.cpp
@@ -35,7 +35,11 @@ namespace WebCore {
 Vector<uint8_t> CryptoKey::randomData(size_t size)
 {
     Vector<uint8_t> result(size);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, result.size(), result.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, result.data(), result.size());
+#endif
     RELEASE_ASSERT(rc == kCCSuccess);
     return result;
 }

--- a/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
@@ -72,7 +72,11 @@ static NSString* masterKeyAccountNameForCurrentApplication()
 static bool createAndStoreMasterKey(Vector<uint8_t>& masterKeyData)
 {
     masterKeyData.resize(masterKeySizeInBytes);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, masterKeyData.size(), masterKeyData.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, masterKeyData.data(), masterKeyData.size());
+#endif
     RELEASE_ASSERT(rc == kCCSuccess);
 
 #if PLATFORM(IOS)
@@ -188,7 +192,11 @@ bool deleteDefaultWebCryptoMasterKey()
 bool wrapSerializedCryptoKey(const Vector<uint8_t>& masterKey, const Vector<uint8_t>& key, Vector<uint8_t>& result)
 {
     Vector<uint8_t> kek(16);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, kek.size(), kek.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, kek.data(), kek.size());
+#endif
     RELEASE_ASSERT(rc == kCCSuccess);
 
     Vector<uint8_t> wrappedKEK(CCSymmetricWrappedSize(kCCWRAPAES, kek.size()));


### PR DESCRIPTION
Use SecRandomCopyBytes instead of CCRandomCopyBytes(private) and use jit version of initializeSeparatedWXHeaps only if USE(APPLE_INTERNAL_SDK)