### PR TITLE
Wrap private api calls in preprocessor checks

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -106,7 +106,7 @@ JS_EXPORTDATA bool useFastPermisionsJITCopy { false };
 
 JS_EXPORTDATA JITWriteSeparateHeapsFunction jitWriteSeparateHeapsFunction;
 
-#if !USE(EXECUTE_ONLY_JIT_WRITE_FUNCTION) && HAVE(REMAP_JIT)
+#if !USE(EXECUTE_ONLY_JIT_WRITE_FUNCTION) && HAVE(REMAP_JIT) && USE(APPLE_INTERNAL_SDK)
 static uintptr_t startOfFixedWritableMemoryPool;
 #endif
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -185,7 +185,7 @@ protected:
     }
 
 private:
-#if OS(DARWIN) && HAVE(REMAP_JIT)
+#if OS(DARWIN) && HAVE(REMAP_JIT) && USE(APPLE_INTERNAL_SDK)
     void initializeSeparatedWXHeaps(void* stubBase, size_t stubSize, void* jitBase, size_t jitSize)
     {
         mach_vm_address_t writableAddr = 0;

--- a/Source/WTF/wtf/RandomDevice.cpp
+++ b/Source/WTF/wtf/RandomDevice.cpp
@@ -84,7 +84,13 @@ RandomDevice::~RandomDevice()
 void RandomDevice::cryptographicallyRandomValues(unsigned char* buffer, size_t length)
 {
 #if OS(DARWIN)
+    
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    RELEASE_ASSERT(!SecRandomCopyBytes(kSecRandomDefault, length, buffer));
+#else
     RELEASE_ASSERT(!CCRandomCopyBytes(kCCRandomDefault, buffer, length));
+#endif
+
 #elif OS(UNIX)
     ssize_t amountRead = 0;
     while (static_cast<size_t>(amountRead) < length) {

--- a/Source/WTF/wtf/RandomDevice.cpp
+++ b/Source/WTF/wtf/RandomDevice.cpp
@@ -42,7 +42,11 @@
 #endif
 
 #if OS(DARWIN)
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+#include <Security/SecRandom.h>
+#else
 #include "CommonCryptoSPI.h"
+#endif
 #endif
 
 namespace WTF {

--- a/Source/WebCore/crypto/mac/CryptoKeyMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyMac.cpp
@@ -35,7 +35,11 @@ namespace WebCore {
 Vector<uint8_t> CryptoKey::randomData(size_t size)
 {
     Vector<uint8_t> result(size);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, result.size(), result.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, result.data(), result.size());
+#endif
     RELEASE_ASSERT(rc == kCCSuccess);
     return result;
 }

--- a/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
@@ -76,7 +76,12 @@ static NSString* masterKeyAccountNameForCurrentApplication()
 static bool createAndStoreMasterKey(Vector<uint8_t>& masterKeyData)
 {
     masterKeyData.resize(masterKeySizeInBytes);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, masterKeyData.size(), masterKeyData.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, masterKeyData.data(), masterKeyData.size());
+#endif
+
     RELEASE_ASSERT(rc == kCCSuccess);
 
 #if PLATFORM(IOS)
@@ -192,7 +197,12 @@ bool deleteDefaultWebCryptoMasterKey()
 bool wrapSerializedCryptoKey(const Vector<uint8_t>& masterKey, const Vector<uint8_t>& key, Vector<uint8_t>& result)
 {
     Vector<uint8_t> kek(16);
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, kek.size(), kek.data());
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, kek.data(), kek.size());
+#endif
+
     RELEASE_ASSERT(rc == kCCSuccess);
 
     Vector<uint8_t> wrappedKEK(CCSymmetricWrappedSize(kCCWRAPAES, kek.size()));

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -62,8 +62,15 @@ ExceptionOr<void> Crypto::getRandomValues(ArrayBufferView& array)
     if (array.byteLength() > 65536)
         return Exception { QUOTA_EXCEEDED_ERR };
 #if OS(DARWIN)
+    
+#if !USE(APPLE_INTERNAL_SDK)
+    int rc = SecRandomCopyBytes(kSecRandomDefault, array.byteLength(), array.baseAddress());
+    RELEASE_ASSERT(rc == errSecSuccess);
+#else
     int rc = CCRandomCopyBytes(kCCRandomDefault, array.baseAddress(), array.byteLength());
     RELEASE_ASSERT(rc == kCCSuccess);
+#endif
+    
 #else
     cryptographicallyRandomValues(array.baseAddress(), array.byteLength());
 #endif

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -32,7 +32,7 @@
 #include "Crypto.h"
 
 #if OS(DARWIN)
-#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+#if !USE(APPLE_INTERNAL_SDK)
 #include <Security/SecRandom.h>
 #else
 #include "CommonCryptoUtilities.h"

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -32,7 +32,11 @@
 #include "Crypto.h"
 
 #if OS(DARWIN)
+#if PLATFORM(IOS) && !USE(APPLE_INTERNAL_SDK)
+#include <Security/SecRandom.h>
+#else
 #include "CommonCryptoUtilities.h"
+#endif
 #endif
 #include "Document.h"
 #include "ExceptionCode.h"


### PR DESCRIPTION
Use SecRandomCopyBytes instead of CCRandomCopyBytes(private) and use jit version of initializeSeparatedWXHeaps only if USE(APPLE_INTERNAL_SDK)