### PR TITLE
feat: Make ConsoleMessage copyable and add a copy constructor

### DIFF
--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -45,9 +45,9 @@ class ScriptArguments;
 class ScriptCallStack;
 
 class JS_EXPORT_PRIVATE ConsoleMessage {
-    WTF_MAKE_NONCOPYABLE(ConsoleMessage);
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    ConsoleMessage(const ConsoleMessage&) = default;
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0);
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::ExecState* = nullptr, unsigned long requestIdentifier = 0);
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, PassRefPtr<ScriptCallStack>, unsigned long requestIdentifier = 0);


### PR DESCRIPTION
We need two copies of the console message so it can be sent to both console agents. Related to https://github.com/NativeScript/ios-runtime/pull/912