### PR TITLE
Change console.time severity level to "info" 

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -172,9 +172,9 @@ std::unique_ptr<ConsoleMessage> InspectorConsoleAgent::stopTiming(const String& 
 
     Seconds elapsed = MonotonicTime::now() - startTime;
     String message = title + String::format(": %.3fms", elapsed.milliseconds());
-    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack.copyRef());
+    std::unique_ptr<ConsoleMessage> consoleMessage = std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Info, message, callStack.copyRef());
     addMessageToConsole(WTFMove(consoleMessage));
-    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, callStack.copyRef());
+    return std::make_unique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Info, message, callStack.copyRef());
 }
 
 void InspectorConsoleAgent::takeHeapSnapshot(const String& title)


### PR DESCRIPTION
In order to show **the console.time** prints in the DevTools Console (with **Default** levels selected), the message severity level should be **info**.

Fixes https://github.com/NativeScript/ios-runtime/issues/1037 