### PR TITLE
fix: reference to 'Handle' is ambiguous

### DIFF
--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -176,7 +176,7 @@ private:
 
 class ElementHandleOwner : public WeakHandleOwner {
 public:
-    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
+    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
     {
         if (UNLIKELY(reason))
             *reason = "JSC::Element is opaque root";


### PR DESCRIPTION
https://trac.macports.org/ticket/59416
<details>
<summary>Part of the compilation errror</summary>

```

Showing All Errors Only
/Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/JSDollarVM.cpp:179:37: Reference to 'Handle' is ambiguous

    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override


                                    ^


In file included from /Users/rigor789/Code/ios-runtime/cmake-build/WebKit-prefix/src/WebKit-build/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource-0284c6ac-1.cpp:1:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellList.cpp:27:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellList.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellProfile.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/JSCast.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/JSCell.h:25:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/CallData.h:31:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/NativeFunction.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/JSCJSValue.h:36:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/MediaTime.h:32:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/JSONValues.h:36:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/text/StringHash.h:25:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/text/AtomString.h:368:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/text/StringConcatenate.h:31:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/text/StringView.h:32:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/WTF/wtf/RetainPtr.h:32:


In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:43:


In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:77:


/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk/usr/include/MacTypes.h:249:41: Candidate found by name lookup is 'Handle'

typedef Ptr *                           Handle;


                                        ^


In file included from /Users/rigor789/Code/ios-runtime/cmake-build/WebKit-prefix/src/WebKit-build/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource-0284c6ac-1.cpp:1:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellList.cpp:27:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellList.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/tools/CellProfile.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/JSCast.h:28:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/runtime/JSCell.h:29:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/heap/Heap.h:32:


In file included from /Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/heap/HandleSet.h:28:


/Users/rigor789/Code/ios-runtime/src/WebKit/Source/JavaScriptCore/heap/Handle.h:109:29: Candidate found by name lookup is 'JSC::Handle'

template <typename T> class Handle : public HandleBase, public HandleConverter<Handle<T>, T> {


```

</details>